### PR TITLE
fixed for haxe 4

### DIFF
--- a/src/haxpression/BinaryOperations.hx
+++ b/src/haxpression/BinaryOperations.hx
@@ -33,31 +33,31 @@ class BinaryOperations {
     addOperator("**", 11, function(left, right) return Math.pow(left.toFloat(), right.toFloat()));
   }
 
-  public static function evaluate(operator, left : Value, right : Value) : Value {
-    return map.get(operator).operation(left, right);
+  public static function evaluate(operant, left : Value, right : Value) : Value {
+    return map.get(operant).operation(left, right);
   }
 
-  public static function addOperator(operator : String, precedence : Int, operation : Value -> Value -> Value) {
-    map.set(operator, {
+  public static function addOperator(operant : String, precedence : Int, operation : Value -> Value -> Value) {
+    map.set(operant, {
       precedence: precedence,
       operation: wrapOperation(operation)
     });
   }
 
-  public static function removeOperator(operator : String) {
-    map.remove(operator);
+  public static function removeOperator(operant : String) {
+    map.remove(operant);
   }
 
-  public static function hasOperator(operator : String) : Bool {
-    return map.exists(operator);
+  public static function hasOperator(operant : String) : Bool {
+    return map.exists(operant);
   }
 
   public static function clearOperators() {
     map = new Map();
   }
 
-  public static function getOperatorPrecedence(operator : String) : Int {
-    return map.get(operator).precedence;
+  public static function getOperatorPrecedence(operant : String) : Int {
+    return map.get(operant).precedence;
   }
 
   public static function getMaxOperatorLength() : Int {

--- a/src/haxpression/Expression.hx
+++ b/src/haxpression/Expression.hx
@@ -49,8 +49,8 @@ abstract Expression(ExpressionType) {
     return switch this {
       case ELiteral(value) : new Value(value).toString();
       case EIdentifier(name) : name;
-      case EUnary(operator, operand): '${operator}${getString(operand)}';
-      case EBinary(operator, left, right) : '(${getString(left)} $operator ${getString(right)})';
+      case EUnary(operant, operand): '${operant}${getString(operand)}';
+      case EBinary(operant, left, right) : '(${getString(left)} $operant ${getString(right)})';
       case ECall(callee, arguments): '${callee}(${getStringDelimited(arguments, ",")})';
       case EConditional(test, consequent, alternate) : '(${getString(test)} ? ${getString(consequent)} : ${getString(alternate)})';
       case EArray(items): '[${getStringDelimited(items, ",")}]';
@@ -75,14 +75,14 @@ abstract Expression(ExpressionType) {
         type: "Identifier",
         name: name
       };
-      case EUnary(operator, operand) : {
+      case EUnary(operant, operand) : {
         type: "Unary",
-        operator: operator,
+        operant: operant,
         operand: (operand : Expression).toObject()
       };
-      case EBinary(operator, left, right) : {
+      case EBinary(operant, left, right) : {
         type: "Binary",
-        operator: operator,
+        operant: operant,
         left: (left : Expression).toObject(),
         right: (right : Expression).toObject()
       };
@@ -163,10 +163,10 @@ abstract Expression(ExpressionType) {
         ELiteral(value);
       case EIdentifier(name) :
         EIdentifier(name);
-      case EUnary(operator, operand) :
-        EUnary(operator, (operand : Expression).clone());
-      case EBinary(operator, left, right) :
-        EBinary(operator, (left : Expression).clone(), (right : Expression).clone());
+      case EUnary(operant, operand) :
+        EUnary(operant, (operand : Expression).clone());
+      case EBinary(operant, left, right) :
+        EBinary(operant, (left : Expression).clone(), (right : Expression).clone());
       case ECall(callee, arguments) :
         ECall(callee, arguments.clone());
       case EConditional(test, consequent, alternate) :
@@ -184,10 +184,10 @@ abstract Expression(ExpressionType) {
         ELiteral(value);
       case EIdentifier(name):
         variables.exists(name) ? variables.get(name).toExpression() : EIdentifier(name);
-      case EUnary(operator, expression):
-        EUnary(operator, (expression : Expression).substitute(variables));
-      case EBinary(operator, left, right):
-        EBinary(operator, (left : Expression).substitute(variables), (right : Expression).substitute(variables));
+      case EUnary(operant, expression):
+        EUnary(operant, (expression : Expression).substitute(variables));
+      case EBinary(operant, left, right):
+        EBinary(operant, (left : Expression).substitute(variables), (right : Expression).substitute(variables));
       case ECall(callee, arguments):
         ECall(callee, arguments.substitute(variables));
       case EConditional(test, consequent, alternate):
@@ -205,17 +205,17 @@ abstract Expression(ExpressionType) {
         ELiteral(value);
       case EIdentifier(name):
         EIdentifier(name);
-      case EUnary(operator, operand):
+      case EUnary(operant, operand):
         if ((operand : Expression).canEvaluate()) {
-          ELiteral(UnaryOperations.evaluate(operator, (operand : Expression).evaluate()));
+          ELiteral(UnaryOperations.evaluate(operant, (operand : Expression).evaluate()));
         } else {
-          EUnary(operator, (operand : Expression).simplify().toExpressionType());
+          EUnary(operant, (operand : Expression).simplify().toExpressionType());
         }
-      case EBinary(operator, left, right):
+      case EBinary(operant, left, right):
         if ((left : Expression).canEvaluate() && (right : Expression).canEvaluate()) {
-          ELiteral(BinaryOperations.evaluate(operator, (left : Expression).evaluate(), (right : Expression).evaluate()));
+          ELiteral(BinaryOperations.evaluate(operant, (left : Expression).evaluate(), (right : Expression).evaluate()));
         } else {
-          EBinary(operator, (left : Expression).simplify(), (right : Expression).simplify());
+          EBinary(operant, (left : Expression).simplify(), (right : Expression).simplify());
         }
       case EConditional(test, consequent, alternate):
         if ((test : Expression).canEvaluate()) {
@@ -244,9 +244,9 @@ abstract Expression(ExpressionType) {
         true;
       case EIdentifier(name):
         false;
-      case EUnary(operator, operand):
+      case EUnary(operant, operand):
         (operand : Expression).canEvaluate();
-      case EBinary(operator, left, right):
+      case EBinary(operant, left, right):
         (left : Expression).canEvaluate() && (right : Expression).canEvaluate();
       case ECall(callee, arguments):
         CallOperations.canEvaluate(callee, arguments);
@@ -276,13 +276,13 @@ abstract Expression(ExpressionType) {
           throw new Error('cannot evaluate expression with unset variable: $name');
         }
         variables.get(name);
-      case EUnary(operator, operand):
+      case EUnary(operant, operand):
         var operandValue = (operand : Expression).evaluate(variables);
-        UnaryOperations.evaluate(operator, operandValue);
-      case EBinary(operator, left, right):
+        UnaryOperations.evaluate(operant, operandValue);
+      case EBinary(operant, left, right):
         var leftValue = (left : Expression).evaluate(variables);
         var rightValue = (right : Expression).evaluate(variables);
-        BinaryOperations.evaluate(operator, leftValue, rightValue);
+        BinaryOperations.evaluate(operant, leftValue, rightValue);
       case ECall(callee, arguments):
         CallOperations.evaluate(callee, arguments.evaluate(variables));
       case EConditional(test, consequent, alternate):
@@ -352,9 +352,9 @@ abstract Expression(ExpressionType) {
       case EIdentifier(name) :
         // Push a variable if we haven't seen it already
         if (variables.indexOf(name) == -1) variables.push(name);
-      case EUnary(operator, operand):
+      case EUnary(operant, operand):
         (operand : Expression).accumulateVariables(variables);
-      case EBinary(operator, left, right):
+      case EBinary(operant, left, right):
         (left : Expression).accumulateVariables(variables);
         (right : Expression).accumulateVariables(variables);
       case ECall(callee, arguments):

--- a/src/haxpression/ExpressionType.hx
+++ b/src/haxpression/ExpressionType.hx
@@ -3,8 +3,8 @@ package haxpression;
 enum ExpressionType {
   ELiteral(value : ValueType);
   EIdentifier(name : String);
-  EUnary(operator : String, operand : ExpressionType);
-  EBinary(operator : String, left : ExpressionType, right : ExpressionType);
+  EUnary(operant : String, operand : ExpressionType);
+  EBinary(operant : String, left : ExpressionType, right : ExpressionType);
   ECall(callee : String, arguments : Array<ExpressionType>);
   EConditional(test : ExpressionType, consequent : ExpressionType, alternate : ExpressionType);
   EArray(items : Array<ExpressionType>);

--- a/src/haxpression/Parser.hx
+++ b/src/haxpression/Parser.hx
@@ -99,6 +99,7 @@ class Parser {
     }
     return null; // not an operator
   }
+  
 
   function gobbleBinaryExpression() : Expression {
     var char : String;
@@ -106,7 +107,7 @@ class Parser {
     var binaryOperator : String;
     var precedence : Int;
     var stack : Array<Dynamic>;
-    var binaryOperatorInfo : { operator : String, precedence : Int };
+    var binaryOperatorInfo : { operant : String, precedence : Int };
     var left : Expression;
     var right : Expression;
     var left = gobbleToken();
@@ -115,7 +116,7 @@ class Parser {
       return left;
     }
     binaryOperatorInfo = {
-      operator: binaryOperator,
+      operant: binaryOperator,
       precedence: BinaryOperations.getOperatorPrecedence(binaryOperator)
     };
     var right = gobbleToken();
@@ -135,13 +136,13 @@ class Parser {
       }
 
       binaryOperatorInfo = {
-        operator: binaryOperator,
+        operant: binaryOperator,
         precedence: precedence
       };
 
       while ((stack.length > 2) && (precedence <= stack[stack.length - 2].precedence)) {
         right = stack.pop();
-        binaryOperator = stack.pop().operator;
+        binaryOperator = stack.pop().operant;
         left = stack.pop();
         var expression = EBinary(binaryOperator, left, right);
         stack.push(expression);
@@ -158,7 +159,7 @@ class Parser {
     var i = stack.length - 1;
     expression = stack[i];
     while (i > 1) {
-      expression = EBinary(stack[i - 1].operator, stack[i - 2], expression);
+      expression = EBinary(stack[i - 1].operant, stack[i - 2], expression);
       i -= 2;
     }
 

--- a/src/haxpression/UnaryOperations.hx
+++ b/src/haxpression/UnaryOperations.hx
@@ -16,22 +16,22 @@ class UnaryOperations {
     addOperator("~", function(value) return ~(value.toInt()));
   }
 
-  public static function evaluate(operator : String, value : Value) : Value {
-    return map.get(operator).operation(value);
+  public static function evaluate(operant : String, value : Value) : Value {
+    return map.get(operant).operation(value);
   }
 
-  public static function addOperator(operator : String, operation : Value -> Value) {
-    map.set(operator, {
+  public static function addOperator(operant : String, operation : Value -> Value) {
+    map.set(operant, {
       operation: wrapOperation(operation)
     });
   }
 
-  public static function removeOperator(operator : String) {
-    map.remove(operator);
+  public static function removeOperator(operant : String) {
+    map.remove(operant);
   }
 
-  public static function hasOperator(operator : String) : Bool {
-    return map.exists(operator);
+  public static function hasOperator(operant : String) : Bool {
+    return map.exists(operant);
   }
 
   public static function clearOperators() {


### PR DESCRIPTION
The issue for this is that `operator` has now become a reserved keyword. I changed the keyword to `operant` just because it was "close enough"